### PR TITLE
Functional tester to display only the needed stream with diff

### DIFF
--- a/tests/tester.py
+++ b/tests/tester.py
@@ -7,9 +7,9 @@ from os import path
 from difflib import unified_diff as diff
 
 
-def get_json_data(filepath: str):
+def get_tests(filepath: str):
     with open(filepath) as json_file:
-        return load_json(json_file)
+        return load_json(json_file)["tests"]
 
 
 def run_command(command: str, piped_path: str):
@@ -19,13 +19,13 @@ def run_command(command: str, piped_path: str):
 def disp_err(tcsh, mysh) -> None:
     if tcsh.stdout not in mysh.stdout:
         print("stdout:")
-        delta = diff(tcsh.stdout.split('\n'), mysh.stdout.split('\n'), "tcsh", "42sh")
+        delta = diff(tcsh.stdout.split(), mysh.stdout.split(), "tcsh", "42sh")
         for line in delta:
             print(line, end="")
         print()
     if tcsh.stderr not in mysh.stderr:
         print("stderr:")
-        delta = diff(tcsh.stderr.split('\n'), mysh.stderr.split('\n'), "tcsh", "42sh")
+        delta = diff(tcsh.stderr.split(), mysh.stderr.split(), "tcsh", "42sh")
         for line in delta:
             print(line, end="")
         print()
@@ -41,23 +41,21 @@ def run_test(isDebug: bool, isFullLog: bool, hasColor: bool) -> bool:
             disp_err(tcsh, mysh)
         print(colored(f'Test "{name}" failed.', "red") if hasColor else f'Test "{name}" failed.')
         return (False)
-    else:
-        if isFullLog:
-            print(colored(f'Test "{name}" passed.', "green") if hasColor else f'Test "{name}" passed.')
-        return (True)
+    if isFullLog:
+        print(colored(f'Test "{name}" passed.', "green") if hasColor else f'Test "{name}" passed.')
+    return (True)
 
 
 if __name__ == "__main__":
-    nb_passed = 0
-    nb_failed = 0
+    nb_passed, nb_failed = 0, 0
     current_path = path.dirname(path.realpath(__file__))
-    json_data = get_json_data(current_path + "/config.json")
-    nb_tests = len(json_data["tests"])
-    isFullLog = True if (len(argv) == 2 and "a" in argv[1]) else False
-    isDebug = True if (len(argv) == 2 and "d" in argv[1]) else False
+    tests = get_tests(current_path + "/config.json")
+    nb_tests = len(tests)
+    isFullLog = (len(argv) == 2 and "a" in argv[1])
+    isDebug = (len(argv) == 2 and "d" in argv[1])
     hasColor = (len(argv) == 2 and "c" in argv[1])
 
-    for test in json_data["tests"]:
+    for test in tests:
         hasPassed = run_test(isDebug, isFullLog, hasColor)
         nb_passed += 1 if hasPassed else 0
         nb_failed += 1 if not hasPassed else 0

--- a/tests/tester.py
+++ b/tests/tester.py
@@ -6,13 +6,21 @@ from termcolor import colored
 from os import path
 
 
-def get_json_data(filepath: str) -> None:
+def get_json_data(filepath: str):
     with open(filepath) as json_file:
         return load_json(json_file)
 
 
-def run_command(command: str, piped_path: str) -> None:
+def run_command(command: str, piped_path: str):
     return run(f'echo "{command}" | {piped_path}', shell=True, capture_output=True, text=True)
+
+
+def disp_err(tcsh, mysh, name: str, debug: bool) -> None:
+    if debug and tcsh.stdout not in mysh.stdout:
+        print(f"TCSH_out:{tcsh.stdout}\n42sh_out:{mysh.stdout}")
+    if debug and tcsh.stderr not in mysh.stderr:
+        print(f"TCSH_err:{tcsh.stderr}\n42sh_err:{mysh.stderr}")
+    print(colored(f'Test "{name}" failed.', "red") if color else f'Test "{name}" failed.')
 
 
 def run_test(debug: bool, disp_all: bool, color: bool) -> None:
@@ -21,10 +29,7 @@ def run_test(debug: bool, disp_all: bool, color: bool) -> None:
     name = test["name"]
 
     if (tcsh.stdout not in mysh.stdout) or (tcsh.stderr not in mysh.stderr):
-        if debug:
-            print(f"TCSH_out:{tcsh.stdout}\n42sh_out:{mysh.stdout}")
-            print(f"TCSH_err:{tcsh.stderr}\n42sh_err:{mysh.stderr}")
-        print(colored(f'Test "{name}" failed.', "red") if color else f'Test "{name}" failed.')
+        disp_err(tcsh, mysh, name, debug)
         return (-1)
     else:
         if disp_all:

--- a/tests/tester.py
+++ b/tests/tester.py
@@ -4,6 +4,7 @@ from subprocess import run
 from sys import argv
 from termcolor import colored
 from os import path
+from difflib import unified_diff as diff
 
 
 def get_json_data(filepath: str):
@@ -17,9 +18,17 @@ def run_command(command: str, piped_path: str):
 
 def disp_err(tcsh, mysh) -> None:
     if tcsh.stdout not in mysh.stdout:
-        print(f"TCSH_out:{tcsh.stdout}\n42sh_out:{mysh.stdout}")
+        print("stdout:")
+        delta = diff(tcsh.stdout.split('\n'), mysh.stdout.split('\n'), "tcsh", "42sh")
+        for line in delta:
+            print(line, end="")
+        print()
     if tcsh.stderr not in mysh.stderr:
-        print(f"TCSH_err:{tcsh.stderr}\n42sh_err:{mysh.stderr}")
+        print("stderr:")
+        delta = diff(tcsh.stderr.split('\n'), mysh.stderr.split('\n'), "tcsh", "42sh")
+        for line in delta:
+            print(line, end="")
+        print()
 
 
 def run_test(isDebug: bool, isFullLog: bool, hasColor: bool) -> bool:


### PR DESCRIPTION
# Description

Filter output to display only the stream with differences (`stdout` and/or `stderr` but not always both).
Displaying the output like a `diff` to show only the matching lines.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the needed labels
- [x] I have linked this PR to an issue
- [ ] I have linked this PR to a milestone
- [ ] I have linked this PR to a project
- [x] I have tested this code
- [x] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs