### PR TITLE
Advanced localvar preload

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -36,10 +36,10 @@ void handle_cd(const env_t *env, const char *path);
 void change_current_path(const char *dir);
 void handle_home(const env_t *env, const char *path);
 void change_home(const env_t *env);
-int handle_cd_silently(env_t **env, const char *path, const char *current);
-int change_dir_silently(env_t **env, const char *dir, const char *current);
-int handle_home_silently(env_t **env, const char *path, const char *current);
-int change_home_silently(env_t **env, const char *current);
+int handle_cd_silently(shell_t *shell, const char *path, const char *current);
+int change_dir_silently(shell_t *shell, const char *dir, const char *current);
+int handle_home_silently(shell_t *shell, const char *path, const char *current);
+int change_home_silently(shell_t *shell, const char *current);
 
 // Signals
 void handle_quit(int sig);

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -68,9 +68,14 @@ void builtin_cd(shell_t *shell, char *const *args)
 {
     size_t size = my_arraylen(args);
     char *path = getcwd(NULL, 0);
+    bool readonly = is_localvar_readonly(shell->localenv, "cwd");
 
     if (path == NULL) {
         fprintf(stderr, "cd: %s.\n", strerror(errno));
+        return;
+    }
+    if (readonly) {
+        fprintf(stderr, "cd: $cwd is read-only.\n");
         return;
     }
     if (size == 1)

--- a/src/builtin/home.c
+++ b/src/builtin/home.c
@@ -44,33 +44,34 @@ void change_home(const env_t *env)
         fprintf(stderr, "cd: Can't change to home directory.\n");
 }
 
-int handle_home_silently(env_t **env, const char *path, const char *current)
+int handle_home_silently(shell_t *shell, const char *path, const char *current)
 {
     int return_value;
     char *result = NULL;
-    const env_t *home = get_env_value(*env, "HOME");
+    const env_t *home = get_env_value(shell->env, "HOME");
 
     if (home == NULL)
         return (1);
     if (strlen(path) == 1)
-        return (change_home_silently(env, current));
+        return (change_home_silently(shell, current));
     result = my_strrep(path, "~", home->value);
-    return_value = change_dir_silently(env, result, current);
+    return_value = change_dir_silently(shell, result, current);
     free(result);
     return (return_value);
 }
 
-int change_home_silently(env_t **env, const char *current)
+int change_home_silently(shell_t *shell, const char *current)
 {
-    const env_t *home = get_env_value(*env, "HOME");
+    const env_t *home = get_env_value(shell->env, "HOME");
     struct stat stats;
     int stat_status = stat((home == NULL ? "" : home->value), &stats);
     bool file = stat_status != -1 && !S_ISDIR(stats.st_mode);
 
     if (home == NULL || chdir(home->value) == -1 || file)
         return (1);
-    add_variable(env, "PWD", home->value);
-    add_variable(env, "OLDPWD", current);
+    add_variable(&shell->env, "PWD", home->value);
+    add_localvar(&shell->localenv, "cwd", home->value, false);
+    add_variable(&shell->env, "OLDPWD", current);
     return (0);
 }
 

--- a/src/builtin/silent.c
+++ b/src/builtin/silent.c
@@ -76,14 +76,14 @@ int silent_cd(shell_t *shell, char *const *args)
     int return_value = 1;
     size_t size = my_arraylen(args);
     char *path = getcwd(NULL, 0);
+    bool readonly = is_localvar_readonly(shell->localenv, "cwd");
 
-    (void) shell;
-    if (path == NULL)
+    if (path == NULL || readonly)
         return (return_value);
     if (size == 1)
-        return_value = change_home_silently(&shell->env, path);
+        return_value = change_home_silently(shell, path);
     else if (size == 2)
-        return_value = handle_cd_silently(&shell->env, args[1], path);
+        return_value = handle_cd_silently(shell, args[1], path);
     free(path);
     return (return_value);
 }

--- a/src/builtin/silent_dirs.c
+++ b/src/builtin/silent_dirs.c
@@ -11,34 +11,36 @@
 #include "shell.h"
 #include "environment.h"
 
-static int handle_prev_silently(env_t **env, const char *path, const char *curr)
+static int handle_prev_silently(shell_t *shell, const char *path,
+const char *current)
 {
-    const env_t *oldpwd = get_env_value(*env, "OLDPWD");
+    const env_t *oldpwd = get_env_value(shell->env, "OLDPWD");
 
     if (strlen(path) > 1 || oldpwd == NULL)
         return (1);
-    return (change_dir_silently(env, oldpwd->value, curr));
+    return (change_dir_silently(shell, oldpwd->value, current));
 }
 
-int handle_cd_silently(env_t **env, const char *path, const char *current)
+int handle_cd_silently(shell_t *shell, const char *path, const char *current)
 {
     size_t size = strlen(path);
 
     if (size > 0 && path[0] == '-')
-        return (handle_prev_silently(env, path, current));
+        return (handle_prev_silently(shell, path, current));
     if (size > 0 && path[0] == '~')
-        return (handle_home_silently(env, path, current));
-    return (change_dir_silently(env, path, current));
+        return (handle_home_silently(shell, path, current));
+    return (change_dir_silently(shell, path, current));
 }
 
-int change_dir_silently(env_t **env, const char *dir, const char *current)
+int change_dir_silently(shell_t *shell, const char *dir, const char *current)
 {
     struct stat stats;
     int st = stat(dir, &stats);
 
     if (st == -1 || !S_ISDIR(stats.st_mode) || chdir(dir) == -1)
         return (1);
-    add_variable(env, "PWD", dir);
-    add_variable(env, "OLDPWD", current);
+    add_variable(&shell->env, "PWD", dir);
+    add_localvar(&shell->localenv, "cwd", dir, false);
+    add_variable(&shell->env, "OLDPWD", current);
     return (0);
 }

--- a/src/environment/local/localenv_load.c
+++ b/src/environment/local/localenv_load.c
@@ -23,18 +23,12 @@ static void add_id_var(unsigned int id, const char *key, shell_t *shell)
     free(value);
 }
 
-void load_localenv(shell_t *shell)
+static void add_user_variables(shell_t *shell)
 {
-    uid_t euid = geteuid();
     uid_t uid = getuid();
-    struct passwd *epw = getpwuid(euid);
     struct passwd *pw = getpwuid(uid);
     struct group *group = NULL;
 
-    if (epw != NULL) {
-        add_id_var(euid, "euid", shell);
-        add_localvar(&shell->localenv, "euser", epw->pw_name, false);
-    }
     if (pw != NULL) {
         group = getgrgid(pw->pw_gid);
         add_id_var(pw->pw_gid, "gid", shell);
@@ -43,4 +37,19 @@ void load_localenv(shell_t *shell)
         add_id_var(uid, "uid", shell);
         add_localvar(&shell->localenv, "user", pw->pw_name, false);
     }
+}
+
+void load_localenv(shell_t *shell)
+{
+    uid_t euid = geteuid();
+    struct passwd *epw = getpwuid(euid);
+    char *cwd = getcwd(NULL, 0);
+
+    add_localvar(&shell->localenv, "cwd", cwd, false);
+    if (epw != NULL) {
+        add_id_var(euid, "euid", shell);
+        add_localvar(&shell->localenv, "euser", epw->pw_name, false);
+    }
+    add_user_variables(shell);
+    free(cwd);
 }


### PR DESCRIPTION
# Description

Advanced localvar preload and usage, such as `cwd` and `ignoreeof`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the needed labels
- [x] I have linked this PR to an issue
- [ ] I have linked this PR to a milestone
- [ ] I have linked this PR to a project
- [ ] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs